### PR TITLE
remove utf8 bom

### DIFF
--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,4 +1,4 @@
-﻿base    pagequery
+base    pagequery
 author  Symon Bent
 email   hendrybadao@gmail.com
 date    2012-03-03


### PR DESCRIPTION
not all dokuwiki versions parse plugin info file properly if file starts with utf8 bom mark

thus the directive "base" is lost, and you can't install this plugin directly from github via plugin manager
