### PR TITLE
Fix for the issue with empty link tags and also one other minor problem I found

### DIFF
--- a/inc/pagequery.php
+++ b/inc/pagequery.php
@@ -353,7 +353,7 @@ class PageQuery {
         if ($raw) {
             $wikilink = $link . $inline;
         } else {
-            $wikilink = '<li class="' . $border . '">' . $link . $inline . '</li>' . DOKU_LF . $after;
+            $wikilink = '<li class="' . $border . '">' . $link . $inline . DOKU_LF . $after . '</li>';
         }
         return $wikilink;
     }
@@ -630,7 +630,7 @@ class PageQuery {
                     }
                     if ( ! is_null($value)) {
                         if (strpos($key, 'date') !== false) {
-                            $value = strftime($opt['dformat'], $value);
+                            $value = utf8_encode(strftime($opt['dformat'], $value));
                         }
                         $display = str_replace($match[0], $value, $display);
                     }


### PR DESCRIPTION
FIX: pagequery sometimes creates empty link tags (see MrBertie/pagequery#22)

FIX: Invalid HTML output when using "snippet=plain" or "snippet=quoted"
