### PR TITLE
Thumbnail feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.class
+*.pyc
+*.pyo
+.project

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,0 @@
-*.class
-*.pyc
-*.pyo
-.project

--- a/action.php
+++ b/action.php
@@ -7,7 +7,7 @@ class action_plugin_pagequery extends DokuWiki_Action_Plugin {
     /**
      * Register the eventhandlers
      */
-    function register(&$controller) {
+    function register(Doku_Event_Handler $controller) {
         $controller->register_hook('TOOLBAR_DEFINE', 'AFTER', $this, 'insert_button', array ());
     }
 

--- a/inc/pagequery.php
+++ b/inc/pagequery.php
@@ -313,7 +313,8 @@ class PageQuery {
      * @return string
      */
     private function _html_wikilink($id, $display, $abstract, $thumbnail, $opt, $track_snippets = true, $raw = false) {
-        static $snippet_cnt = 0;
+		global $INFO;
+	    static $snippet_cnt = 0;
 
         if ($track_snippets) {
             $snippet_cnt++;
@@ -324,22 +325,27 @@ class PageQuery {
         $type = $opt['snippet']['type'];
         $inline = '';
         $after = '';
-		$thumbnail_html = '';
+        $thumbnail_html = '';
 
         $count = $opt['snippet']['count'];
         $skip_snippet = ($count > 0 && $snippet_cnt >= $count);
-		
+
 		if ( !empty( $thumbnail ) ) {
+			// Build the array of necessary data
 			$thumbnail_data = array(
-				'src' 		=> $thumbnail,
-				'title'		=> $id,
-				'align'		=> $opt['thumbnail']['align'],
-				'width'		=> $opt['thumbnail']['width'],
-				'height'	=> $opt['thumbnail']['height'],
-				'cache'		=> 'cache',
-				'type'		=> 'internalmedia'
+				'src'     => $thumbnail,
+				'title'   => $id,
+				'align'   => $opt['thumbnail']['align'],
+				'width'   => $opt['thumbnail']['width'],
+				'height'  => $opt['thumbnail']['height'],
+				'cache'   => 'cache',
 			);
-			$thumbnail_html = html_wikilink($id, $thumbnail_data);
+			// Check if we are dealing with an internal image
+			if ( !media_isexternal( $thumbnail ) ) {
+				$thumbnail_data['type'] = 'internalmedia';
+			}
+			// Get the link and image
+			$thumbnail_html = html_wikilink( $id, $thumbnail_data );
 		}
 
         if ($type == 'tooltip') {
@@ -364,6 +370,9 @@ class PageQuery {
         }
 
         $border = ($opt['underline']) ? 'border' : '';
+		if ( $id == $INFO['id'] ) {
+			$border .= ' current';
+		}
         if ($raw) {
             $wikilink = $link . $inline;
         } else {
@@ -663,12 +672,10 @@ class PageQuery {
                 $display = $row['name'];
             }
             $row['display'] = $display;
-			
-			// Get the first image for the thumbnail, but only if it's a local file
+
+			// Get the page's first image, if available
 			if ( isset( $meta['relation']['firstimage'] ) ) {
-				if ( !strpos( $meta['relation']['firstimage'], '://' ) ) {
-					$row['thumbnail'] = $meta['relation']['firstimage'];	
-				}
+				$row['thumbnail'] = $meta['relation']['firstimage'];
 			}
 
             $cnt++;

--- a/inc/pagequery.php
+++ b/inc/pagequery.php
@@ -353,7 +353,7 @@ class PageQuery {
         if ($raw) {
             $wikilink = $link . $inline;
         } else {
-            $wikilink = '<li class="' . $border . '">' . $link . $inline . '</li>' . DOKU_LF . $after;
+            $wikilink = '<li class="' . $border . '">' . $link . $inline . DOKU_LF . $after . '</li>';
         }
         return $wikilink;
     }
@@ -630,7 +630,7 @@ class PageQuery {
                     }
                     if ( ! is_null($value)) {
                         if (strpos($key, 'date') !== false) {
-                            $value = strftime($opt['dformat'], $value);
+                            $value = utf8_encode(strftime($opt['dformat'], $value));
                         }
                         $display = str_replace($match[0], $value, $display);
                     }

--- a/inc/pagequery.php
+++ b/inc/pagequery.php
@@ -1,13 +1,12 @@
 <?php
 
-
 require_once(DOKU_INC . 'inc/fulltext.php');
-
 
 
 class PageQuery {
 
     private $lang = array();
+    private $snippet_cnt = 0;
 
     function __construct(Array $lang) {
         $this->lang = $lang;
@@ -35,11 +34,19 @@ class PageQuery {
 
 
     function render_as_html($layout, $sorted_results, $opt, $count) {
+        $this->snippet_cnt = $opt['snippet']['count'];
         $render_type = '_render_as_html_' . $layout;
         return $this->$render_type($sorted_results, $opt, $count);
     }
 
-
+    /**
+     * Used by the render_as_html_table function below
+     * **DEPRECATED**
+     *
+     * @param $sorted_results
+     * @param $ratios
+     * @return int
+     */
     private function _adjusted_height($sorted_results, $ratios) {
         // ratio of different heading heights (%), to ensure more even use of columns (h1 -> h6)
         $adjusted_height = 0;
@@ -53,7 +60,8 @@ class PageQuery {
     /**
      * Render the final pagequery results list as HTML, indented and in columns as required.
      *
-     * DEPRECATED --- I would like to scrap this ASAP (old browsers only).
+     * **DEPRECATED** --- I would like to scrap this ASAP (old browsers only).
+     * It's complicated and it's hard to maintain.
      *
      * @param array  $sorted_results
      * @param array  $opt
@@ -152,6 +160,9 @@ class PageQuery {
                 if ( ! $prev_was_heading) {
                     $render .= '</ul>' . DOKU_LF;
                 }
+                if ($opt['nstitle'] && ! empty($display)) {
+                    $heading = $display;
+                }
                 if ($opt['proper'] == 'header' || $opt['proper'] == 'both') {
                     $heading = $this->_proper($heading);
                 }
@@ -201,46 +212,28 @@ class PageQuery {
      */
     protected function _render_as_html_column($sorted_results, $opt, $count) {
 
-        $render = '';
         $prev_was_heading = false;
         $cont_level = 1;
         $is_first = true;
-
-        $fontsize = '';
-        $outer_border = '';
-        $inner_border = '';
-        $show_count = '';
-        $label = '';
-        $show_jump = '';
-        $list_style = '';
-
-        // A fixed anchor to jump back to at top
-        $top_id = 'top-' . mt_rand();
+        $top_id = 'top-' . mt_rand();   // A fixed anchor at top to jump back to
 
         // CSS for the various display options
-        if ( ! empty($opt['fontsize'])) {
-            $fontsize = 'font-size:' . $opt['fontsize'];
-        }
-        if ($opt['border'] == 'outside' || $opt['border'] == 'both') {
-            $outer_border = 'border';
-        }
-        if ($opt['border'] == 'inside'|| $opt['border'] == 'both') {
-            $inner_border =  'inner-border" ';
-        }
-        if ($opt['showcount'] == true) {
-            $show_count = '<div class="count">' . $count . ' ∞</div>' . DOKU_LF;
-        }
-        if ($opt['label'] != '') {
-            $label = '<h1 class="title">' . $opt['label'] . '</h1>' . DOKU_LF;
-        }
-        if ($opt['hidejump'] === false) {
-            $show_jump = '<a class="top" href="#' . $top_id . '">' . $this->lang['link_to_top'] . '</a>' . DOKU_LF;
-        }
-        if ($opt['bullet'] != 'none') {
-            $list_style = 'list-style-position:inside;list-style-type:' . $opt['bullet'];
-        }
+        $fontsize = ( ! empty($opt['fontsize'])) ?
+            'font-size:' . $opt['fontsize'] : '';
+        $outer_border = ($opt['border'] == 'outside' || $opt['border'] == 'both') ?
+            'border' : '';
+        $inner_border =  ($opt['border'] == 'inside'|| $opt['border'] == 'both') ?
+            'inner-border' : '';
+        $show_count = ($opt['showcount'] == true) ?
+            '<div class="count">' . $count . ' ∞</div>' . DOKU_LF : '';
+        $label = ($opt['label'] != '') ?
+            '<h1 class="title">' . $opt['label'] . '</h1>' . DOKU_LF : '';
+        $show_jump = ($opt['hidejump'] === false) ?
+            '<a class="top" href="#' . $top_id . '">' . $this->lang['link_to_top'] . '</a>' . DOKU_LF : '';
+        $list_style = ($opt['bullet'] != 'none') ?
+            'list-style-position:inside;list-style-type:' . $opt['bullet'] : '';
 
-        // no grouping = no indenting
+        // no grouping => no indenting
         $can_indent = $opt['group'];
 
         // now prepare the actual pagequery list
@@ -259,12 +252,15 @@ class PageQuery {
                 $indent_style = '';
             }
 
-            // finally display the appropriate heading or page link(s)
+            // finally display the appropriate heading...
             if ($is_heading) {
 
-                // close previous sub list if necessary
+                // close previous subheading list if necessary
                 if ( ! $prev_was_heading) {
                     $pagequery .= '</ul>' . DOKU_LF;
+                }
+                if ($opt['nstitle'] && ! empty($display)) {
+                    $heading = $display;
                 }
                 if ($opt['proper'] == 'header' || $opt['proper'] == 'both') {
                     $heading = $this->_proper($heading);
@@ -276,6 +272,7 @@ class PageQuery {
                 $prev_was_heading = true;
                 $cont_level = $level + 1;
 
+            // ...or page link(s)
             } else {
                 // open a new sub list if necessary
                 if ($prev_was_heading || $is_first) {
@@ -292,6 +289,8 @@ class PageQuery {
             $is_first = false;
         }
 
+        // and put it all together for display
+        $render = '';
         $render .= '<div class="pagequery ' . $outer_border . '" id="' . $top_id . '" style="' . $fontsize . '">' . DOKU_LF;
         $render .= $show_count . $show_jump . $label . DOKU_LF;
         $render .= '<div class="inner ' . $inner_border . '">' . DOKU_LF;
@@ -313,12 +312,8 @@ class PageQuery {
      * @return string
      */
     private function _html_wikilink($id, $display, $abstract, $thumbnail, $opt, $track_snippets = true, $raw = false) {
-		global $INFO;
-	    static $snippet_cnt = 0;
+        global $INFO;
 
-        if ($track_snippets) {
-            $snippet_cnt++;
-        }
         $id = (strpos($id, ':') === false) ? ':' . $id : $id;   // : needed for root pages (root level)
 
         $link = html_wikilink($id, $display);
@@ -327,10 +322,7 @@ class PageQuery {
         $after = '';
         $thumbnail_html = '';
 
-        $count = $opt['snippet']['count'];
-        $skip_snippet = ($count > 0 && $snippet_cnt >= $count);
-
-		if ( !empty( $thumbnail ) && !empty( $opt[ 'thumbnail' ] ) ) {
+        if ( !empty( $thumbnail ) && !empty( $opt[ 'thumbnail' ] ) ) {
 			// Build the array of necessary data
 			$thumbnail_data = array(
 				'src'     => $thumbnail,
@@ -353,7 +345,7 @@ class PageQuery {
             $tooltip = htmlentities($tooltip, ENT_QUOTES, 'UTF-8');
             $link = $this->_add_tooltip($link, $tooltip);
 
-        } elseif (in_array($type, array('quoted', 'plain', 'inline')) && ! $skip_snippet) {
+        } elseif (in_array($type, array('quoted', 'plain', 'inline')) && $this->snippet_cnt > 0) {
             $short = $this->_shorten($abstract, $opt['snippet']['extent']);
             $short = htmlentities($short, ENT_QUOTES, 'UTF-8');
             if ( ! empty($short)) {
@@ -378,6 +370,9 @@ class PageQuery {
         } else {
             $wikilink = '<li class="' . $border . '">' . $thumbnail_html . $link . $inline . DOKU_LF . $after . '</li>';
         }
+        if ($track_snippets) {
+            $this->snippet_cnt--;
+        }
         return $wikilink;
     }
 
@@ -401,12 +396,12 @@ class PageQuery {
      *
      * @param string $text
      * @param string $extent  c? = ? chars, w? = ? words, l? = ? lines, ~? = search up to text/char/symbol
-     * @param string $more
+     * @param string $more  symbol to show if more text
      * @return  string
      */
     private function _shorten($text, $extent, $more = '... ') {
         $elem = $extent[0];
-        $cnt = substr($extent, 1);
+        $cnt = (int) substr($extent, 1);
         switch ($elem) {
             case 'c':
                 $result = substr($text, 0, $cnt);
@@ -441,9 +436,28 @@ class PageQuery {
     private function _proper($id) {
         $id = str_replace(':', ': ', $id); // make a little whitespace before words so ucwords can work!
         $id = str_replace('_', ' ', $id);
-        $id = ucwords($id);
+        $id = utf8_ucwords($id);
         $id = str_replace(': ', ':', $id);
         return $id;
+    }
+
+
+    /**
+     * a mb version of 'ucwords' that respects capitalised words
+     * does not work for hyphenated words (yet)
+     * **UNUSED**
+     */
+    private function _mb_ucwords($str) {
+        $result = array();
+        $words = mb_split('\s', $str);
+        foreach ($words as $word) {
+            if (mb_strtoupper($word) == $word) {
+                $result[] = $word;
+            } else {
+                $result[] = mb_convert_case($word, MB_CASE_TITLE, "UTF-8");
+            }
+        }
+        return implode(' ', $result);
     }
 
 
@@ -567,7 +581,7 @@ class PageQuery {
                     case 'a':
                     case 'ab':
                     case 'abc':
-                        $value = $this->_first(strtolower($abc), strlen($key));
+                        $value = $this->_first($abc, strlen($key));
                         break;
                     case 'name':
                     case 'title':
@@ -667,7 +681,7 @@ class PageQuery {
             } elseif (isset($row[$display])) {
                 $display = $row[$display];
 
-                // if all else fails then used the page name (always available)
+                // if all else fails then use the page name (always available)
             } else {
                 $display = $row['name'];
             }
@@ -782,9 +796,9 @@ class PageQuery {
     }
 
 
-    // returns first $count letters from $text
+    // returns first $count letters from $text in lowercase
     private function _first($text, $count) {
-        $result = ($count > 0) ? utf8_substr($text, 0, $count) : '';
+        $result = ($count > 0) ? utf8_substr(utf8_strtolower($text), 0, $count) : '';
         return $result;
     }
 
@@ -1186,9 +1200,10 @@ class PageQuery {
             if ($group_type === self::MGROUP_HEADING) {
                 $date_format = $group_opts['dformat'][$level];
                 if ( ! empty($date_format)) {
-                    // the real date is always the the '__realdate__' column (MGROUP_REALDATE)
+                    // the real date is always the '__realdate__' column (MGROUP_REALDATE)
                     $cur = strftime($date_format, $sort_array[$idx][self::MGROUP_REALDATE]);
                 }
+                // args : $level, $name, $id, $_, $abstract, $display
                 $results[] = array($level + 1, $cur, '');
 
             } elseif ($group_type === self::MGROUP_NAMESPACE) {
@@ -1199,8 +1214,15 @@ class PageQuery {
                     if ($cur_ns[$i] != $prev_ns[$i]) {
                         $hl = $level + $i + 1;
                         $id = implode(':', array_slice($cur_ns, 0, $i + 1)) . ':' . $conf['start'];
-                        $ns_start = (page_exists($id)) ? $id : '';
-                        $results[] = array($hl , $cur_ns[$i], $ns_start, '', '');
+                        if (page_exists($id)) {
+                            $ns_start = $id;
+                            // allow the first heading to be used instead of page id/name
+                            $display = p_get_metadata($id, 'title');
+                        } else {
+                            $ns_start = $display = '';
+                        }
+                        // args : $level, $name, $id, $_, $abstract, $display
+                        $results[] = array($hl , $cur_ns[$i], $ns_start, '', '', $display);
                     }
                 }
             }

--- a/inc/pagequery.php
+++ b/inc/pagequery.php
@@ -330,7 +330,7 @@ class PageQuery {
         $count = $opt['snippet']['count'];
         $skip_snippet = ($count > 0 && $snippet_cnt >= $count);
 
-		if ( !empty( $thumbnail ) ) {
+		if ( !empty( $thumbnail ) && !empty( $opt[ 'thumbnail' ] ) ) {
 			// Build the array of necessary data
 			$thumbnail_data = array(
 				'src'     => $thumbnail,

--- a/lang/ja/lang.php
+++ b/lang/ja/lang.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ *
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ */
+
+$lang['no_results']   = '検索照会の結果がありません：« %1s »';
+$lang['jump_section'] = '上の « %1$s » セクションに続きます...'; // '%1$s' は該当見出しで置換されます
+$lang['jump_to_top']  = 'このページ一覧の先頭に戻る';
+$lang['link_to_top']  = '先頭 ↑';
+$lang['regex_error']  = '正規表現にエラーがあります。確認してやり直してください。';
+$lang['empty_filter'] = 'フィルター式は、結果なしを返しました。';

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base    pagequery
 author  Symon Bent
 email   hendrybadao@gmail.com
-date    2013-10-11
+date    2014-11-09
 name    PageQuery Plugin
 desc    Search for (fulltext) and list wiki pages, sorted and optionally grouped by name, date, creator, abc, etc. in columns. Insert the pagequery markup wherever you want your list to appear.  E.g.{{pagequery>[query;fulltext;sort=key:direction,key2:direction;group;limit=??;cols=?;inwords;proper]}} [..] = optional
 url     http://www.dokuwiki.org/plugin:pagequery

--- a/syntax.php
+++ b/syntax.php
@@ -91,7 +91,7 @@ class syntax_plugin_pagequery extends DokuWiki_Syntax_Plugin {
         $opt['sort']      = array();    // sort by various headings
         $opt['spelldate'] = false;      // spell out date headings in words where possible
         $opt['underline'] = false;      // faint underline below each link for clarity
-        $opt['thumbnail'] = array('width' => null, 'heigth' => null, 'align' => ''); // first image in page
+        $opt['thumbnail'] = array( 'width' => 100, 'heigth' => null, 'align' => '' ); // first image in page
 
         foreach ($params as $param) {
             list($option, $value) = explode('=', $param);
@@ -220,38 +220,34 @@ class syntax_plugin_pagequery extends DokuWiki_Syntax_Plugin {
                     }
                     break;
 				case 'thumbnail':
-					if ( !empty( $value ) ) {
-						$thumb_details = explode( ',', strtolower( $value ) );
-						foreach ( $thumb_details as $thumb_detail ) {
-							// Determine image size (width and height are given)
-							if ( strpos( $thumb_detail, 'x' ) ) {
-								$thumb_size = explode( 'x', $thumb_detail );
-								$thumb_size = array_map( 'intval', $thumb_size );
-								if ( $thumb_size[0] > 0 ) {
-									$opt['thumbnail']['width'] = $thumb_size[0];
-								}
-								if ( $thumb_size[1] > 0 ) {
-									$opt['thumbnail']['height'] = $thumb_size[1];
-								}
+					$thumb_details = explode( ',', strtolower( $value ) );
+					$thumb_details = array_slice( $thumb_details, 0, 2 ); // Allow a maximum of 2 arguments
+					$thumb_details = array_map( 'trim', $thumb_details );
+					foreach ( $thumb_details as $thumb_detail ) {
+						// Allow for full size images
+						if ( $thumb_detail == '0' || $thumb_detail == '0x0' ) {
+							$opt['thumbnail']['height'] = null;
+							$opt['thumbnail']['width'] = null;
+						}
+						// Determine image size (both width and height are given)
+						elseif ( strpos( $thumb_detail, 'x' ) ) {
+							$thumb_size = explode( 'x', $thumb_detail );
+							$thumb_size = array_map( 'intval', $thumb_size );
+							if ( $thumb_size[0] > 0 ) {
+								$opt['thumbnail']['width'] = $thumb_size[0];
 							}
-							// Determine image size (only width is given)
-							elseif ( is_numeric( $thumb_detail ) && intval( $thumb_detail ) > 0 ) {
-								$opt['thumbnail']['width'] = intval( $thumb_detail );
-							}
-							// Determine image alignment
-							elseif ( in_array( $thumb_detail, array( '', 'center', 'left', 'right' ) ) ) {
-								$opt['thumbnail']['align'] = $thumb_detail;
+							if ( $thumb_size[1] > 0 ) {
+								$opt['thumbnail']['height'] = $thumb_size[1];
 							}
 						}
-						
-						// If no image size was given by the user, set the width to default
-						if ( is_null( $opt['thumbnail']['width'] ) ) {
-							$opt['thumbnail']['width'] = 100;
+						// Determine image size (only width is given)
+						elseif ( is_numeric( $thumb_detail ) && intval( $thumb_detail ) > 0 ) {
+							$opt['thumbnail']['width'] = intval( $thumb_detail );
 						}
-					}
-					else {
-						// Default thumbnail size, when nothing else is given
-						$opt['thumbnail']['width'] = 100;
+						// Determine image alignment
+						elseif ( in_array( $thumb_detail, array( 'center', 'left', 'right' ) ) ) {
+							$opt['thumbnail']['align'] = $thumb_detail;
+						}
 					}
 					break;
             }

--- a/syntax.php
+++ b/syntax.php
@@ -91,7 +91,7 @@ class syntax_plugin_pagequery extends DokuWiki_Syntax_Plugin {
         $opt['sort']      = array();    // sort by various headings
         $opt['spelldate'] = false;      // spell out date headings in words where possible
         $opt['underline'] = false;      // faint underline below each link for clarity
-        $opt['thumbnail'] = array( 'width' => 100, 'heigth' => null, 'align' => '' ); // first image in page
+        $opt['thumbnail'] = array();    // first image in page
 
         foreach ($params as $param) {
             list($option, $value) = explode('=', $param);
@@ -220,6 +220,9 @@ class syntax_plugin_pagequery extends DokuWiki_Syntax_Plugin {
                     }
                     break;
 				case 'thumbnail':
+					// Set defaults here
+					$opt['thumbnail'] = array( 'width' => 100, 'heigth' => null, 'align' => '' );
+					
 					$thumb_details = explode( ',', strtolower( $value ) );
 					$thumb_details = array_slice( $thumb_details, 0, 2 ); // Allow a maximum of 2 arguments
 					$thumb_details = array_map( 'trim', $thumb_details );

--- a/syntax.php
+++ b/syntax.php
@@ -221,31 +221,36 @@ class syntax_plugin_pagequery extends DokuWiki_Syntax_Plugin {
                     break;
 				case 'thumbnail':
 					if ( !empty( $value ) ) {
-						// Determine image alignment
-						if ( substr( $value, 0, 1 ) == ' ' && substr( $value, -1, 1 ) == ' ' ) {
-							$opt['thumbnail']['align'] = 'center';
-						}
-						elseif ( substr( $value, 0, 1 ) == ' ' ) {
-							$opt['thumbnail']['align'] = 'right';
-						}
-						elseif ( substr( $value, -1, 1 ) == ' ' ) {
-							$opt['thumbnail']['align'] = 'left';
+						$thumb_details = explode( ',', strtolower( $value ) );
+						foreach ( $thumb_details as $thumb_detail ) {
+							// Determine image size (width and height are given)
+							if ( strpos( $thumb_detail, 'x' ) ) {
+								$thumb_size = explode( 'x', $thumb_detail );
+								$thumb_size = array_map( 'intval', $thumb_size );
+								if ( $thumb_size[0] > 0 ) {
+									$opt['thumbnail']['width'] = $thumb_size[0];
+								}
+								if ( $thumb_size[1] > 0 ) {
+									$opt['thumbnail']['height'] = $thumb_size[1];
+								}
+							}
+							// Determine image size (only width is given)
+							elseif ( is_numeric( $thumb_detail ) && intval( $thumb_detail ) > 0 ) {
+								$opt['thumbnail']['width'] = intval( $thumb_detail );
+							}
+							// Determine image alignment
+							elseif ( in_array( $thumb_detail, array( '', 'center', 'left', 'right' ) ) ) {
+								$opt['thumbnail']['align'] = $thumb_detail;
+							}
 						}
 						
-						$thumb_size = explode( 'x', strtolower( $value ) );
-						$thumb_size = array_map( 'intval', $thumb_size );
-						// Check if a valid image width was given
-						if ( $thumb_size[0] > 0 ) {
-							$opt['thumbnail']['width'] = $thumb_size[0];
+						// If no image size was given by the user, set the width to default
+						if ( is_null( $opt['thumbnail']['width'] ) ) {
+							$opt['thumbnail']['width'] = 100;
 						}
-						// Check if a valid image height was given
-						if ( isset( $thumb_size[1] ) ) {
-							if ( $thumb_size[1] > 0 ) {
-								$opt['thumbnail']['height'] = $thumb_size[1];
-							}
-						}						
 					}
 					else {
+						// Default thumbnail size, when nothing else is given
 						$opt['thumbnail']['width'] = 100;
 					}
 					break;

--- a/syntax.php
+++ b/syntax.php
@@ -91,6 +91,7 @@ class syntax_plugin_pagequery extends DokuWiki_Syntax_Plugin {
         $opt['sort']      = array();    // sort by various headings
         $opt['spelldate'] = false;      // spell out date headings in words where possible
         $opt['underline'] = false;      // faint underline below each link for clarity
+        $opt['thumbnail'] = array('width' => null, 'heigth' => null, 'align' => ''); // first image in page
 
         foreach ($params as $param) {
             list($option, $value) = explode('=', $param);
@@ -218,6 +219,36 @@ class syntax_plugin_pagequery extends DokuWiki_Syntax_Plugin {
                         $opt['fontsize'] = $value;
                     }
                     break;
+				case 'thumbnail':
+					if ( !empty( $value ) ) {
+						// Determine image alignment
+						if ( substr( $value, 0, 1 ) == ' ' && substr( $value, -1, 1 ) == ' ' ) {
+							$opt['thumbnail']['align'] = 'center';
+						}
+						elseif ( substr( $value, 0, 1 ) == ' ' ) {
+							$opt['thumbnail']['align'] = 'right';
+						}
+						elseif ( substr( $value, -1, 1 ) == ' ' ) {
+							$opt['thumbnail']['align'] = 'left';
+						}
+						
+						$thumb_size = explode( 'x', strtolower( $value ) );
+						$thumb_size = array_map( 'intval', $thumb_size );
+						// Check if a valid image width was given
+						if ( $thumb_size[0] > 0 ) {
+							$opt['thumbnail']['width'] = $thumb_size[0];
+						}
+						// Check if a valid image height was given
+						if ( isset( $thumb_size[1] ) ) {
+							if ( $thumb_size[1] > 0 ) {
+								$opt['thumbnail']['height'] = $thumb_size[1];
+							}
+						}						
+					}
+					else {
+						$opt['thumbnail']['width'] = 100;
+					}
+					break;
             }
         }
         return $opt;
@@ -306,7 +337,7 @@ class syntax_plugin_pagequery extends DokuWiki_Syntax_Plugin {
                 $count = count($sort_array);
 
                 // and finally the grouping
-                $keys = array('name', 'id', 'title', 'abstract', 'display');
+                $keys = array('name', 'id', 'title', 'abstract', 'display', 'thumbnail');
                 if ( ! $opt['group']) $group_opts = array();
                 $sorted_results = $pq->mgroup($sort_array, $keys, $group_opts);
 


### PR DESCRIPTION
Hello Symon,

A few weeks ago I took the time to look into the thumbnail (i.e. first image in page) feature for pagequery. This was the single feature I missed most in pagequery and I noticed that it had also been requested by someone else on the plugin discussions page. 

So I added a new option called **thumbnail** which accepts a maximum of two optional comma separated parameters:
- One parameter defines the desired **image size** and can either be a number (defining just the width) or two numbers separated by the letter x (defining width and height) just like DokuWiki’s image syntax. If omitted, the image will be displayed with a width of 100 pixels and automatic height. In case the user gives a size of 0 or 0x0 the image will be displayed in **full size** (I don’t know how useful this is but some users may want this).
- The other parameter can be either **center**, **left** or **right** and defines the desired **alignment** of the image. If omitted, no alignment is used and the image will be displayed inline.

A few more notes:
- The URL of the image is taken from the page’s metadata field relation→firstimage.
- The thumbnail option has no effect whatsoever on the output of the “main” link as configured by the display option.
- The thumbnail image will always be displayed immediately after the opening li-Tag and before the “main” link. Also it will always be wrapped in a link itself because the html_wikilink function is used to output the image.
- Works with internal and external images (although cropping of external images may not work depending on the DokuWiki and server configuration).

I hope you can merge this into pagequery in one form or another so other people can benefit from it as well. If you have any ideas about changes or improvements of this implementation I’d be happy to help.

Kind regards,
Thomas
