### PR TITLE
Add option `fulltextregex` to search page content with regex

### DIFF
--- a/inc/pagequery.php
+++ b/inc/pagequery.php
@@ -856,7 +856,7 @@ class PageQuery {
             
             $text = io_readFile(wikiFN($page, '', false), false);
             
-            $matched = preg_match('/' . $query . '/i', $text);
+            $matched = preg_match('/' . $query . '/iS', $text);
             if ($matched === false) {
                 return false;
             } elseif ($matched == 0) {
@@ -911,7 +911,7 @@ class PageQuery {
              *  and the page-exists check above
              * The @ prevents problems with invalid queries!
              */
-            $matched = @preg_match('/' . $query . '/i', $page);
+            $matched = @preg_match('/' . $query . '/iS', $page);
             if ($matched === false) {
                 return false;
             } elseif ($matched == 0) {

--- a/res/toolbar
+++ b/res/toolbar
@@ -1,6 +1,7 @@
 pagequery>	* | .* | exclude ns: ^ |-ns: | include ns: @ | ns: | . | .. | text | regex
 fulltext	Full-text search of page content
 fullregex	Search the full page id using regex
+fulltextregex Full-text search of page content using regex
 sort=column:direction	Keys to sort by, in order of sorting
 - a, ab, abc	By 1st letter, 2-letters, or 3-letters
 - name, pagename	By page name [not grouped]

--- a/syntax.php
+++ b/syntax.php
@@ -76,6 +76,7 @@ class syntax_plugin_pagequery extends DokuWiki_Syntax_Plugin {
         $opt['fontsize']  = '';         // base fontsize of pagequery; best to use %
         $opt['fullregex'] = false;      // power-user regex search option--file name only
         $opt['fulltext']  = false;      // search full-text; including file contents
+        $opt['fulltextregex']  = false; // search full-text; including file contents, using preg_match
         $opt['group']     = false;      // group the results based on sort headings
         $opt['hidejump']  = false;      // hide the jump to top link
         $opt['hidemsg']   = false;      // hide any error messages
@@ -99,6 +100,7 @@ class syntax_plugin_pagequery extends DokuWiki_Syntax_Plugin {
                 case 'casesort':
 				case 'fullregex':
                 case 'fulltext':
+                case 'fulltextregex':
                 case 'group':
                 case 'hidejump':
                 case 'hidemsg':
@@ -272,8 +274,14 @@ class syntax_plugin_pagequery extends DokuWiki_Syntax_Plugin {
                 if ($query == '*') {
                     $query = '.*';
                 }
-                // search by page name or path only
-                $results = $pq->page_lookup($query, $opt['fullregex'], $incl_ns, $excl_ns);
+                
+                if($opt['fulltextregex'] == true) {
+                    // search by page name or path only
+                    $results = $pq->page_search_regex($query, $incl_ns, $excl_ns);
+                } else {
+                    // search by page name or path only
+                    $results = $pq->page_lookup($query, $opt['fullregex'], $incl_ns, $excl_ns);
+                }
             }
             $results = $pq->validate_pages($results, $opt['hidestart'], $opt['maxns']);
 


### PR DESCRIPTION
dokuwiki fulltext search can be slow and unreliable. Add option to use regex over all page content. 