### PR TITLE
Increase compatibility with PHP 7

### DIFF
--- a/inc/pagequery.php
+++ b/inc/pagequery.php
@@ -782,7 +782,7 @@ class PageQuery {
      * @return string
      */
     private function _date_format($key) {
-        $dkey = '';
+        $dkey = array();
         if (strpos($key, 'year') !== false) $dkey[] = '%Y';
         if (strpos($key, 'month') !== false) $dkey[] = '%m';
         if (strpos($key, 'day') !== false) $dkey[] = '%d';


### PR DESCRIPTION
For PHP 7, arrays must be declared explicitly. The code was failing when it attempted to use the short array push syntax on a variable that was initialized as a string.